### PR TITLE
support for intoto v0.0.2 entries

### DIFF
--- a/src/modules/components/Intoto.tsx
+++ b/src/modules/components/Intoto.tsx
@@ -3,11 +3,12 @@ import { dump } from "js-yaml";
 import NextLink from "next/link";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { atomDark } from "react-syntax-highlighter/dist/cjs/styles/prism";
-import { IntotoV001Schema } from "rekor";
+import { IntotoV002Schema } from "rekor";
 import { decodex509 } from "../x509/decode";
 
-export function IntotoViewer({ intoto }: { intoto: IntotoV001Schema }) {
-	const certContent = window.atob(intoto.publicKey || "");
+export function IntotoViewer({ intoto }: { intoto: IntotoV002Schema }) {
+	const signature = intoto.content.envelope?.signatures[0];
+	const certContent = window.atob(signature?.publicKey || "");
 
 	const publicKey = {
 		title: "Public Key",
@@ -52,7 +53,7 @@ export function IntotoViewer({ intoto }: { intoto: IntotoV001Schema }) {
 				language="text"
 				style={atomDark}
 			>
-				{intoto.publicKey || ""}
+				{window.atob(signature?.sig || "")}
 			</SyntaxHighlighter>
 			<Typography
 				variant="h5"


### PR DESCRIPTION
Updates the search results to properly render entries persisted w/ the intoto v0.0.2 schema type.

I suspect that the v0.0.2 schema didn't exist at the time that this interface was originally implemented but all intoto entries published in the past few months will be using the new schema. At some point we could probably update this to support both v0.0.1 and v0.0.2, but for now it's probably more important for v0.0.2 records to render properly.

**Before:**
<img width="1166" alt="image" src="https://user-images.githubusercontent.com/398027/226772251-95d52c34-c8f6-4891-a263-89a9075bf332.png">

**After:**
<img width="1180" alt="image" src="https://user-images.githubusercontent.com/398027/226772335-46a1a5e5-5fb6-42b5-a624-a7e935a90e28.png">
